### PR TITLE
New feature split coverage file by suite or Behat feature

### DIFF
--- a/src/BehatLocalCodeCoverage/LocalCodeCoverageExtension.php
+++ b/src/BehatLocalCodeCoverage/LocalCodeCoverageExtension.php
@@ -37,6 +37,10 @@ final class LocalCodeCoverageExtension implements Extension
                     ->isRequired()
                     ->info('The directory where the generated coverage files should be stored.')
                 ->end()
+                ->scalarNode('split_by')
+                    ->defaultValue('suite')
+                    ->info('The strategy to save/split coverage files by (suite or feature).')
+                ->end()
             ->end();
     }
 
@@ -47,5 +51,6 @@ final class LocalCodeCoverageExtension implements Extension
 
         $container->setParameter('local_code_coverage.phpunit_xml_path', $config['phpunit_xml_path']);
         $container->setParameter('local_code_coverage.target_directory', $config['target_directory']);
+        $container->setParameter('local_code_coverage.split_by', $config['split_by']);
     }
 }

--- a/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
+++ b/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace BehatLocalCodeCoverage;
 
+use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
+use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;

--- a/src/BehatLocalCodeCoverage/Resources/config/services.yml
+++ b/src/BehatLocalCodeCoverage/Resources/config/services.yml
@@ -4,5 +4,6 @@ services:
         arguments:
             - '%local_code_coverage.phpunit_xml_path%'
             - '%local_code_coverage.target_directory%'
+            - '%local_code_coverage.split_by%'
         tags:
             - { name: event_dispatcher.subscriber }


### PR DESCRIPTION
Please consider merging this new feature to split coverage files by Behat feature. The default is still set to save by `suite` with a new configuration option of `split_by: 'feature'`. Thank you! 😸 