### PR TITLE
Feature: Scenario Outline support

### DIFF
--- a/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
+++ b/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
@@ -7,6 +7,7 @@ use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
 use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Behat\Behat\EventDispatcher\Event\OutlineTested;
 use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
 use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use LiveCodeCoverage\CodeCoverageFactory;
@@ -54,6 +55,9 @@ final class LocalCodeCoverageListener implements EventSubscriberInterface
             SuiteTested::BEFORE => 'beforeSuite',
             ScenarioTested::BEFORE => 'beforeScenario',
             ScenarioTested::AFTER => 'afterScenario',
+            ScenarioTested::AFTER => 'afterScenario',
+            OutlineTested::BEFORE => 'beforeScenarioOutline',
+            OutlineTested::AFTER => 'beforeScenarioOutline',
             FeatureTested::AFTER => 'afterFeature',
             SuiteTested::AFTER => 'afterSuite'
         ];
@@ -83,6 +87,26 @@ final class LocalCodeCoverageListener implements EventSubscriberInterface
     }
 
     public function afterScenario(ScenarioLikeTested $event)
+    {
+        if (!$this->coverageEnabled) {
+            return;
+        }
+
+        $this->coverage->stop();
+    }
+
+    public function beforeScenarioOutline(OutlineTested $event)
+    {
+        if (!$this->coverageEnabled) {
+            return;
+        }
+
+        $coverageId = $event->getFeature()->getFile() . ':' . $event->getOutline()->getLine();
+
+        $this->coverage->start($coverageId);
+    }
+
+    public function afterScenarioOutline(OutlineTested $event)
     {
         if (!$this->coverageEnabled) {
             return;

--- a/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
+++ b/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
@@ -55,7 +55,6 @@ final class LocalCodeCoverageListener implements EventSubscriberInterface
             SuiteTested::BEFORE => 'beforeSuite',
             ScenarioTested::BEFORE => 'beforeScenario',
             ScenarioTested::AFTER => 'afterScenario',
-            ScenarioTested::AFTER => 'afterScenario',
             OutlineTested::BEFORE => 'beforeScenarioOutline',
             OutlineTested::AFTER => 'beforeScenarioOutline',
             FeatureTested::AFTER => 'afterFeature',

--- a/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
+++ b/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace BehatLocalCodeCoverage;
 
 use Behat\Behat\EventDispatcher\Event\AfterFeatureTested;
+use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
-use Behat\Behat\EventDispatcher\Event\OutlineTested;
 use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
 use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use LiveCodeCoverage\CodeCoverageFactory;
@@ -55,8 +55,8 @@ final class LocalCodeCoverageListener implements EventSubscriberInterface
             SuiteTested::BEFORE => 'beforeSuite',
             ScenarioTested::BEFORE => 'beforeScenario',
             ScenarioTested::AFTER => 'afterScenario',
-            OutlineTested::BEFORE => 'beforeScenarioOutline',
-            OutlineTested::AFTER => 'beforeScenarioOutline',
+            ExampleTested::BEFORE => 'beforeScenario',
+            ExampleTested::AFTER => 'afterScenario',
             FeatureTested::AFTER => 'afterFeature',
             SuiteTested::AFTER => 'afterSuite'
         ];
@@ -86,26 +86,6 @@ final class LocalCodeCoverageListener implements EventSubscriberInterface
     }
 
     public function afterScenario(ScenarioLikeTested $event)
-    {
-        if (!$this->coverageEnabled) {
-            return;
-        }
-
-        $this->coverage->stop();
-    }
-
-    public function beforeScenarioOutline(OutlineTested $event)
-    {
-        if (!$this->coverageEnabled) {
-            return;
-        }
-
-        $coverageId = $event->getFeature()->getFile() . ':' . $event->getOutline()->getLine();
-
-        $this->coverage->start($coverageId);
-    }
-
-    public function afterScenarioOutline(OutlineTested $event)
     {
         if (!$this->coverageEnabled) {
             return;


### PR DESCRIPTION
Scenario Outline did not have coverage reported, so I have added support for this :)

Could have been done through using `getNode` instead of `getScenario` / `getOutline`, but sadly the interfaces Behat supplies don't line up for this :<