### PR TITLE
Avoid TypeError if suite is aborted

### DIFF
--- a/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
+++ b/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php
@@ -108,8 +108,13 @@ final class LocalCodeCoverageListener implements EventSubscriberInterface
         Storage::storeCodeCoverage($this->coverage, $this->targetDirectory, sprintf('%s-%s', basename($parts['dirname']), $parts['filename']));
     }
 
-    public function afterSuite(AfterSuiteTested $event)
+    public function afterSuite(SuiteTested $event)
     {
+        // there could also be an AfterSuiteAborted event
+        if (! $event instanceof AfterSuiteTested) {
+            return;
+        }
+
         if (!$this->coverageEnabled || $this->coverage === null) {
             return;
         }


### PR DESCRIPTION
This extension breaks with a TypeError if the behat suite is aborted, e.g. due to a scenario failure:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to BehatLocalCodeCoverage\LocalCodeCoverageListener::afterSuite() must be an instance of Behat\Testwork\EventDispatcher\Event\AfterSuiteTested, instance of Behat\Testwork\EventDispatcher\Event\AfterSuiteAborted given, called in /opt/raisenow/app/vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php on line 214 and defined in /app/vendor/matthiasnoback/behat-local-code-coverage-extension/src/BehatLocalCodeCoverage/LocalCodeCoverageListener.php:111
```

As it seems that Behat does not provide a more granular set of events the listener can subscribe to, this PR widens the function argument to the parent class of the `AfterSuiteTested` but returns immediately if it is not an instance of such. 